### PR TITLE
(MAINT) Add main ref to action docs examples

### DIFF
--- a/.github/actions/commenting/expectations/v1/readme.md
+++ b/.github/actions/commenting/expectations/v1/readme.md
@@ -78,7 +78,7 @@ jobs:
         id: checkout_repo
         uses: actions/checkout@v3
       - name: Comment on Community PRs
-        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/commenting/expectations/v1
+        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/commenting/expectations/v1@main
         with:
           message_path: .github/messages/expectations.md
           token: ${{ github.token }}
@@ -112,7 +112,7 @@ jobs:
         shell: pwsh
     steps:
       - name: Comment on Community PRs
-        uses: ./.github/actions/commenting/expectations/v1
+        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/commenting/expectations/v1@main
         with:
           token: ${{ github.token }}
           message_body: |

--- a/.github/actions/verification/authorization/v1/readme.md
+++ b/.github/actions/verification/authorization/v1/readme.md
@@ -51,7 +51,7 @@ jobs:
         shell: pwsh
     steps:
       - name: Authorized to Target Live Branch?
-        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/verification/authorization/v1
+        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/verification/authorization/v1@main
         with:
           token: ${{ github.token }}
 ```

--- a/.github/actions/verification/checklist/v1/readme.md
+++ b/.github/actions/verification/checklist/v1/readme.md
@@ -83,7 +83,7 @@ jobs:
     steps:
       - name: Verify Checklist
         id: verify_checklist
-        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/verification/checklist/v1
+        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/verification/checklist/v1@main
 ```
 
 This workflow uses the `pull_request` trigger to verify whether the checklist included in the Pull


### PR DESCRIPTION
# PR Summary

Prior to this change, the examples in the documentation for the actions did not include the `@main` ref postfix. A ref postfix is necessary for actions in other repositories.

Because these actions do not use tagged versions, they should specify `@main` instead.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
